### PR TITLE
adapter-electron: add optional path parameter for load

### DIFF
--- a/packages/adapter-electron/functions/index.d.ts
+++ b/packages/adapter-electron/functions/index.d.ts
@@ -1,2 +1,2 @@
-export function load(mainWindow: any, port: string | undefined): void;
+export function load(mainWindow: any, port: string | undefined, path: string | undefined): void;
 export function start(): Promise<string | undefined>;

--- a/packages/adapter-electron/functions/index.js
+++ b/packages/adapter-electron/functions/index.js
@@ -31,12 +31,12 @@ export const start = async () => {
 };
 
 /** @type {import('./index.js').load} */
-export const load = (mainWindow, port) => {
+export const load = (mainWindow, port, path = '') => {
   if (isDev && process.env['ELECTRON_RENDERER_URL']) {
-    log.info(`Loading url: ${process.env['ELECTRON_RENDERER_URL']}`);
-    mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL']);
+    log.info(`Loading url: ${process.env['ELECTRON_RENDERER_URL']}${path}`);
+    mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL']+path);
   } else {
-    log.info(`Loading url: http://localhost:${port}`);
-    mainWindow.loadURL(`http://localhost:${port}`);
+    log.info(`Loading url: http://localhost:${port}${path}`);
+    mainWindow.loadURL(`http://localhost:${port}${path}`);
   }
 };


### PR DESCRIPTION
I have a Usecase where i want to be able to open multiple different windows, which all have different paths. So lets say

- https://localhost:5137/path1
- https://localhost:5137/path2

The provided functions lacked the ability to achieve this.